### PR TITLE
Specify vendor-supplied system header files via '-isystem'.

### DIFF
--- a/rust-crosscompiler-armv6/include/arm-linux-gnueabihf-gcc-with-link-search
+++ b/rust-crosscompiler-armv6/include/arm-linux-gnueabihf-gcc-with-link-search
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 arm-linux-gnueabihf-gcc \
-        -I/opt/rpi-fs/usr/include/arm-linux-gnueabihf \
-        -I/opt/rpi-fs/usr/include \
+        -isystem/opt/rpi-fs/usr/include/arm-linux-gnueabihf \
+        -isystem/opt/rpi-fs/usr/include \
         -L/opt/rpi-fs/usr/lib/arm-linux-gnueabihf \
         -L/opt/rpi-fs/usr/lib \
         $@


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html
