### PR TITLE
Point OBJCOPY to rpi binary; fixes #9

### DIFF
--- a/arm/Dockerfile
+++ b/arm/Dockerfile
@@ -10,6 +10,7 @@ ENV CC arm-linux-gnueabihf-gcc-with-link-search
 ENV CXX arm-linux-gnueabihf-g++-with-link-search
 ENV PATH $CC_DIR:$PATH:/root/.cargo/bin
 ENV ROOT_FS /
+ENV OBJCOPY $CC_DIR/arm-linux-gnueabihf-objcopy
 
 COPY include/config /tmp/.cargo/
 COPY include/arm-linux-gnueabihf-gcc-with-link-search /usr/local/sbin/


### PR DESCRIPTION
According to [this isse comment on backtrace-sys](https://github.com/alexcrichton/backtrace-rs/issues/25#issuecomment-279742551) and [this PR](https://github.com/alexcrichton/backtrace-rs/pull/29), we need to point the `OBJCOPY` environment variable at the right `objcopy`. In this case, that's `arm-linux-gnueabihf-objcopy` from the raspberry pi tools.

Fixes #9.