### PR TITLE
Create an image based off of debian:stretch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+language: generic
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,15 @@ env:
   - secure: SHBqfQevgggt0CNmJ2nT5ltAz9UYcd3OWM+hOCk2aAxNt3KVqmqqlMJqqcNxt14raHIDFKf5YSP4eWc/nodGXXjvW1Vme2rmB/DoyF4kbZmbQnhOsStsyf4lhhHfORhTSGpCsW8nos3xvzXfG9TL4+2Blt/nmRj4ZwNaL8/yR5Ur95IWGUczJXsZU0TdnGIGlc6KL9Ysw7SLUocWKcdO8ReyFrP7JjrmqdHfXsRsGZVyqop7Q8vujiZUHAj1Ebp5CbegH7E4T0IVcejkiN7UjY22+ZPAsBdp1D2pjXXYB5uDCbvOtyx29DUrMAPdoNlg/TcidMyav4xYw6IfzMSOAJBVg+pS1hVGIVKPGCEeYB+O4V+b8/A8IizfM5aqZvTtNuTxj188hWiH6YKHNtdinV8XeYzTUIlBZVTYJStLpBEmQbNfHBjSRhbyB98VeS03gbpOUyqOnLp0VV9dtLX+USX+Nh7wgoLwgWp++vqUWms5TRIP4mCl+qIXiPVV2iPEKXfyxtteBKq73677tm7ubPbYrr1w7Uga9M9ELC4Jwh6vOh4aEWtawVVCLE7HckUARETy0Im8TTYIw39qeSHrXOjgnHQtplhMV+BCKp/Jgtym6Is13L1AwqKyeDhD0o8EFwGMWAgQoU5Zt4Az1KzZlOQIYtptzFw2Wp4pYpowU9Y=
   # DOCKER_EMAIL
   - secure: "JvpYTNBwavjvUTG4GC2waRDxzgjz8WL9F/xqpCFJI1TPKco3NqU16OXkOJB5RB8JmVnzeQgqOzveiRzMlLRDBdihQLgPZs1+iAOBmSp9qUhyxITImxPsiyuPVrvCn51QFim3PxS89GaNKwPM1rNxTH36Xz8DNP9cvr+ekcwrEJmM2ui5pwdhU6MhQd3t8BCBp5Mtv/4dqeFtzTt8AvwKS8Aifnid19JHnkLF4BjMHSRnYeeITUEF04YYqqca1LDKA92aB0boCHC9hNwljBvXiejaTCsXxQTkckOBjvBd3br57oasMdde9mggAFsAKdoY1OMbI527+Q0+gXXDBtToluy2mkzy1iOCDUXyAMioSs54HY/VPCcI25+ibcmkiINrFqYC3qoW53g3XQmDghzxQSAqp5sJT37MJaBem2VOe2Wd4191VCwi3EaRc7P9Gc7lfOjren9WwhEczWmKIvEdR2CFmzBszBnpVTcl68xa7xE0UQpd3KVcl/QL/wGalRRntZsQaojPTS8hII/QyVVfLJarYk0DmN5N2wWmFq7UxhIQvL0kIk3yrFCV/yVtcrTrWyVcvqNC6Cfnr4EJGE+zhPuPkrVfmFnF1vAR/RalwI3EiFFEmowVMN9Q6GbRBCFuD/2h8N3sYFtecEQm+nfbGGi48aXLmFwkwQ9r7nsJYNg="
+  matrix:
+  - TAG=stable PATH=arm
+  - TAG=stable-stretch PATH=arm-stretch
 
 script:
-  - docker build -t dlecan/rust-crosscompiler-arm:stable arm
+  - docker build -t dlecan/rust-crosscompiler-arm:${TAG} ${PATH}
 
 after_success:
-  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD" && docker push dlecan/rust-crosscompiler-arm
+  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD" && docker push dlecan/rust-crosscompiler-arm:${TAG}
   
   
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ sudo chown -R `stat -c %u:%g $HOME` $(pwd) ~/.cargo
 
 You can then `rxc cargo build`.
 
+## Debian Stretch
+
+Rust projects that have a dependency or transititive dependency on
+[openssl-sys](https://crates.io/crates/openssl-sys) need to be compiled with
+the correct openssl version for their target. In practice, this means that Rust
+code compiled on Debian Jessie will expect libssl.so.1.0.0 and not run on
+Debian Stretch with libssl.so.1.0.2, and vice versa.
+
+To compile for a Debian Stretch target, use
+`dlecan/rust-crosscompiler-arm:stable-stretch`, which has a Debian Stretch
+base.
+
 ## Usage with script
 
 ## Inspiration

--- a/arm-stretch/Dockerfile
+++ b/arm-stretch/Dockerfile
@@ -1,0 +1,53 @@
+FROM debian:stretch
+MAINTAINER Damien Lecan <dev@dlecan.com>
+
+#ENV USER root
+ENV CHANNEL stable
+
+ENV CC_DIR /opt/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin
+ENV REAL_CC $CC_DIR/arm-linux-gnueabihf-gcc
+ENV CC arm-linux-gnueabihf-gcc-with-link-search
+ENV CXX arm-linux-gnueabihf-g++-with-link-search
+ENV PATH $CC_DIR:$PATH:/root/.cargo/bin
+ENV ROOT_FS /
+ENV OBJCOPY $CC_DIR/arm-linux-gnueabihf-objcopy
+ENV PKG_CONFIG_ALLOW_CROSS 1
+
+COPY include/config /tmp/.cargo/
+COPY include/arm-linux-gnueabihf-gcc-with-link-search /usr/local/sbin/
+COPY include/arm-linux-gnueabihf-g++-with-link-search /usr/local/sbin/
+COPY include/fixQualifiedLibraryPaths.sh /usr/local/sbin/
+COPY include/cargo /usr/local/sbin/
+
+RUN mv /tmp/.cargo $HOME && \
+  dpkg --add-architecture armhf && \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    file \
+    pkg-config \
+    curl \
+    crossbuild-essential-armhf \
+    libssl1.0-dev \
+    libssl1.0-dev:armhf && \
+  curl https://sh.rustup.rs -sSf | sh /dev/stdin -y && \
+  PATH=$PATH:$HOME/.cargo/bin && \
+  rustup target add arm-unknown-linux-gnueabihf && \
+  curl -sSL https://github.com/raspberrypi/tools/archive/master.tar.gz \
+  | tar -zxC /opt tools-master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64 --strip=2 && \
+  fixQualifiedLibraryPaths.sh $ROOT_FS $REAL_CC && \
+  DEBIAN_FRONTEND=noninteractive apt-get remove --purge -y curl && \
+  DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+  rm -rf \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/* && \
+  mkdir -p /source
+
+VOLUME ["/root/.cargo/git", "/root/.cargo/registry"]
+
+VOLUME ["/source"]
+WORKDIR /source
+
+CMD ["cargo", "build", "--release"]

--- a/arm-stretch/include/arm-linux-gnueabihf-g++-with-link-search
+++ b/arm-stretch/include/arm-linux-gnueabihf-g++-with-link-search
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# /!\ Same config for gcc
+
+arm-linux-gnueabihf-g++ \
+        -isystem/usr/include/arm-linux-gnueabihf \
+        -isystem/usr/include \
+        -L/usr/lib/arm-linux-gnueabihf \
+        -L/usr/lib \
+        $@
+

--- a/arm-stretch/include/arm-linux-gnueabihf-gcc-with-link-search
+++ b/arm-stretch/include/arm-linux-gnueabihf-gcc-with-link-search
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# /!\ Same config for g++
+
+arm-linux-gnueabihf-gcc \
+        -isystem/usr/include/arm-linux-gnueabihf \
+        -isystem/usr/include \
+        -L/usr/lib/arm-linux-gnueabihf \
+        -L/usr/lib \
+        $@
+

--- a/arm-stretch/include/cargo
+++ b/arm-stretch/include/cargo
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/root/.cargo/bin/cargo $@ --target=arm-unknown-linux-gnueabihf

--- a/arm-stretch/include/config
+++ b/arm-stretch/include/config
@@ -1,0 +1,2 @@
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc-with-link-search"

--- a/arm-stretch/include/fixQualifiedLibraryPaths.sh
+++ b/arm-stretch/include/fixQualifiedLibraryPaths.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#This script is ugly, feel free to fix it
+
+if [ "$#" -ne 2 ]; then
+    echo "usage ./cmd target-rootfs target-toolchain"
+    exit -1
+fi
+
+#passed args
+ROOTFS=$1
+TOOLCHAIN=$2
+
+if [ -x $TOOLCHAIN ]; then
+    echo "Passed valid toolchain"
+    MACHINE=$($TOOLCHAIN -dumpmachine)
+    DEB_MULTI_ARCH_MADNESS=$ROOTFS/usr/lib/$MACHINE
+fi
+
+CURRENTDIR=$PWD
+
+function adjustSymLinks
+{
+    echo "Adjusting the symlinks in $1 to be relative"
+    cd $1
+    find . -maxdepth 1 -type l | while read i;
+    do qualifies=$(file $i | sed -e "s/.*\`\(.*\)'/\1/g" | grep ^/lib)
+    if [ -n "$qualifies" ]; then
+    newPath=$(file $i | sed -e "s/.*\`\(.*\)'/\1/g" | sed -e "s,\`,,g" | sed -e "s,',,g" | sed -e "s,^/lib,$2/lib,g");
+    echo $i
+    echo $newPath;
+    #sudo rm $i;
+    rm $i;
+    #sudo ln -s $newPath $i;
+    ln -s $newPath $i;
+    fi
+    done
+}
+
+adjustSymLinks $ROOTFS/usr/lib "../.."
+
+if [ -n "$DEB_MULTI_ARCH_MADNESS" -a -d "$DEB_MULTI_ARCH_MADNESS" ]; then
+    echo "Debian multiarch dir exists, adjusting"
+    adjustSymLinks $DEB_MULTI_ARCH_MADNESS "../../.."
+fi
+
+cd $CURRENTDIR


### PR DESCRIPTION
Add a Dockerfile that builds a similar image to
rust-crosscompiler-arm:stable, but that uses debian:stretch as the base
image instead of debian:jessie.

This solves an issue where cross-compiling with openssl-sys links to the
correct library that is provided with each release.

Fixes #15